### PR TITLE
bump debian version to 12 for docker, add support for non-x86_64 hosts for docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM debian:9-slim as base
+FROM debian:12-slim as base
+
+ARG ARCH=x86_64
+ENV ARCH $ARCH
 
 ENV FFMPEG_VERSION=4.0.2 LD_LIBRARY_PATH=/usr/local/lib
 
@@ -43,7 +46,10 @@ RUN ldd /usr/bin/mediainfo
 #
 # Runtime Container
 #
-FROM debian:9-slim as slim
+FROM debian:12-slim as slim
+
+ARG ARCH=x86_64
+ENV ARCH $ARCH
 
 ENV FFMPEG_VERSION=4.0.2 LD_LIBRARY_PATH=/usr/local/lib
 
@@ -53,7 +59,7 @@ COPY --from=base /usr/local/lib/libavformat.so.* /usr/local/lib/
 COPY --from=base /usr/local/lib/libavcodec.so.* /usr/local/lib/
 COPY --from=base /usr/local/lib/libavutil.so.* /usr/local/lib/
 COPY --from=base /usr/local/lib/libswresample.so.* /usr/local/lib/
-COPY --from=base /usr/lib/x86_64-linux-gnu/libOpenCL.so.* /usr/local/lib/
+COPY --from=base /usr/lib/${ARCH}-linux-gnu/libOpenCL.so.* /usr/local/lib/
 COPY --from=base /usr/local/lib/libgpac.so /usr/local/lib/
 
 # ensure all required libraries are installed
@@ -61,41 +67,47 @@ RUN if ldd /usr/local/bin/caption-inspector | grep "not found"; then false; fi
 
 COPY --from=base /usr/bin/mediainfo /usr/local/bin/mediainfo
 # copy required libraries from base to the slim image
-COPY --from=base /usr/lib/x86_64-linux-gnu/libmediainfo.so.* /usr/local/lib/
-COPY --from=base /usr/lib/x86_64-linux-gnu/libzen.so.* /usr/local/lib/
-COPY --from=base /usr/lib/x86_64-linux-gnu/libcurl-gnutls.so.* /usr/local/lib/
-COPY --from=base /usr/lib/x86_64-linux-gnu/libmms.so.* /usr/local/lib/
-COPY --from=base /lib/x86_64-linux-gnu/libglib-2.0.so.* /usr/local/lib/
-COPY --from=base /usr/lib/x86_64-linux-gnu/libtinyxml2.so.* /usr/local/lib/
-COPY --from=base /usr/lib/x86_64-linux-gnu/libnghttp2.so.* /usr/local/lib/
-COPY --from=base /usr/lib/x86_64-linux-gnu/libidn2.so.* /usr/local/lib/
-COPY --from=base /usr/lib/x86_64-linux-gnu/librtmp.so.* /usr/local/lib/
-COPY --from=base /usr/lib/x86_64-linux-gnu/libssh2.so.* /usr/local/lib/
-COPY --from=base /usr/lib/x86_64-linux-gnu/libpsl.so.* /usr/local/lib/
-COPY --from=base /usr/lib/x86_64-linux-gnu/libnettle.so.* /usr/local/lib/
-COPY --from=base /usr/lib/x86_64-linux-gnu/libgnutls.so.* /usr/local/lib/
-COPY --from=base /usr/lib/x86_64-linux-gnu/libgssapi_krb5.so.* /usr/local/lib/
-COPY --from=base /usr/lib/x86_64-linux-gnu/libkrb5.so.* /usr/local/lib/
-COPY --from=base /usr/lib/x86_64-linux-gnu/libk5crypto.so.* /usr/local/lib/
-COPY --from=base /usr/lib/x86_64-linux-gnu/liblber-2.4.so.* /usr/local/lib/
-COPY --from=base /usr/lib/x86_64-linux-gnu/libldap_r-2.4.so.* /usr/local/lib/
-COPY --from=base /usr/lib/x86_64-linux-gnu/libunistring.so.* /usr/local/lib/
-COPY --from=base /usr/lib/x86_64-linux-gnu/libhogweed.so.* /usr/local/lib/
-COPY --from=base /usr/lib/x86_64-linux-gnu/libgmp.so.* /usr/local/lib/
-COPY --from=base /usr/lib/x86_64-linux-gnu/libunistring.so.* /usr/local/lib/
-COPY --from=base /usr/lib/x86_64-linux-gnu/libp11-kit.so.* /usr/local/lib/
-COPY --from=base /lib/x86_64-linux-gnu/libidn.so.* /usr/local/lib/
-COPY --from=base /usr/lib/x86_64-linux-gnu/libtasn1.so.* /usr/local/lib/
-COPY --from=base /usr/lib/x86_64-linux-gnu/libhogweed.so.* /usr/local/lib/
-COPY --from=base /usr/lib/x86_64-linux-gnu/libgmp.so.* /usr/local/lib/
-COPY --from=base /usr/lib/x86_64-linux-gnu/libkrb5support.so.* /usr/local/lib/
-COPY --from=base /lib/x86_64-linux-gnu/libkeyutils.so.* /usr/local/lib/
-COPY --from=base /usr/lib/x86_64-linux-gnu/libkrb5support.so.* /usr/local/lib/
-COPY --from=base /lib/x86_64-linux-gnu/libkeyutils.so.* /usr/local/lib/
-COPY --from=base /usr/lib/x86_64-linux-gnu/libkrb5support.so.* /usr/local/lib/
-COPY --from=base /lib/x86_64-linux-gnu/libkeyutils.so.* /usr/local/lib/
-COPY --from=base /usr/lib/x86_64-linux-gnu/libsasl2.so.* /usr/local/lib/
-COPY --from=base /usr/lib/x86_64-linux-gnu/libffi.so.* /usr/local/lib/
+COPY --from=base /usr/lib/${ARCH}-linux-gnu/libmediainfo.so.* /usr/local/lib/
+COPY --from=base /usr/lib/${ARCH}-linux-gnu/libzen.so.* /usr/local/lib/
+COPY --from=base /usr/lib/${ARCH}-linux-gnu/libcurl-gnutls.so.* /usr/local/lib/
+COPY --from=base /usr/lib/${ARCH}-linux-gnu/libmms.so.* /usr/local/lib/
+COPY --from=base /lib/${ARCH}-linux-gnu/libglib-2.0.so.* /usr/local/lib/
+COPY --from=base /usr/lib/${ARCH}-linux-gnu/libtinyxml2.so.* /usr/local/lib/
+COPY --from=base /usr/lib/${ARCH}-linux-gnu/libnghttp2.so.* /usr/local/lib/
+COPY --from=base /usr/lib/${ARCH}-linux-gnu/libidn2.so.* /usr/local/lib/
+COPY --from=base /usr/lib/${ARCH}-linux-gnu/librtmp.so.* /usr/local/lib/
+COPY --from=base /usr/lib/${ARCH}-linux-gnu/libssh2.so.* /usr/local/lib/
+COPY --from=base /usr/lib/${ARCH}-linux-gnu/libpsl.so.* /usr/local/lib/
+COPY --from=base /usr/lib/${ARCH}-linux-gnu/libnettle.so.* /usr/local/lib/
+COPY --from=base /usr/lib/${ARCH}-linux-gnu/libgnutls.so.* /usr/local/lib/
+COPY --from=base /usr/lib/${ARCH}-linux-gnu/libgssapi_krb5.so.* /usr/local/lib/
+COPY --from=base /usr/lib/${ARCH}-linux-gnu/libkrb5.so.* /usr/local/lib/
+COPY --from=base /usr/lib/${ARCH}-linux-gnu/libk5crypto.so.* /usr/local/lib/
+COPY --from=base /usr/lib/${ARCH}-linux-gnu/liblber-2.4.so.* /usr/local/lib/
+COPY --from=base /usr/lib/${ARCH}-linux-gnu/libldap_r-2.4.so.* /usr/local/lib/
+COPY --from=base /usr/lib/${ARCH}-linux-gnu/libunistring.so.* /usr/local/lib/
+COPY --from=base /usr/lib/${ARCH}-linux-gnu/libhogweed.so.* /usr/local/lib/
+COPY --from=base /usr/lib/${ARCH}-linux-gnu/libgmp.so.* /usr/local/lib/
+COPY --from=base /usr/lib/${ARCH}-linux-gnu/libunistring.so.* /usr/local/lib/
+COPY --from=base /usr/lib/${ARCH}-linux-gnu/libp11-kit.so.* /usr/local/lib/
+COPY --from=base /lib/${ARCH}-linux-gnu/libidn.so.* /usr/local/lib/
+COPY --from=base /usr/lib/${ARCH}-linux-gnu/libtasn1.so.* /usr/local/lib/
+COPY --from=base /usr/lib/${ARCH}-linux-gnu/libhogweed.so.* /usr/local/lib/
+COPY --from=base /usr/lib/${ARCH}-linux-gnu/libgmp.so.* /usr/local/lib/
+COPY --from=base /usr/lib/${ARCH}-linux-gnu/libkrb5support.so.* /usr/local/lib/
+COPY --from=base /lib/${ARCH}-linux-gnu/libkeyutils.so.* /usr/local/lib/
+COPY --from=base /usr/lib/${ARCH}-linux-gnu/libkrb5support.so.* /usr/local/lib/
+COPY --from=base /lib/${ARCH}-linux-gnu/libkeyutils.so.* /usr/local/lib/
+COPY --from=base /usr/lib/${ARCH}-linux-gnu/libkrb5support.so.* /usr/local/lib/
+COPY --from=base /lib/${ARCH}-linux-gnu/libkeyutils.so.* /usr/local/lib/
+COPY --from=base /usr/lib/${ARCH}-linux-gnu/libsasl2.so.* /usr/local/lib/
+COPY --from=base /usr/lib/${ARCH}-linux-gnu/libffi.so.* /usr/local/lib/
+COPY --from=base /usr/lib/${ARCH}-linux-gnu/libldap-2.5.so.* /usr/local/lib/
+COPY --from=base /usr/lib/${ARCH}-linux-gnu/liblber-2.5.so.* /usr/local/lib/
+COPY --from=base /usr/lib/${ARCH}-linux-gnu/libbrotlidec.so.* /usr/local/lib/
+COPY --from=base /usr/lib/${ARCH}-linux-gnu/libcrypto.so.* /usr/local/lib/
+COPY --from=base /lib/${ARCH}-linux-gnu/libbrotlicommon.so.* /usr/local/lib/
+COPY --from=base /lib/${ARCH}-linux-gnu/libresolv.so.* /usr/local/lib/
 
 # ensure all required libraries are installed
 RUN if ldd /usr/local/bin/mediainfo | grep "not found"; then false; fi

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ ci_with_gpac:
 	cd src ; make ci_with_gpac
 
 docker:
-	docker build -t caption-inspector .
+	docker build -t caption-inspector . --build-arg ARCH=${ARCH}
 
 docker-test:
 	cd test ; make docker
@@ -85,6 +85,7 @@ clean:
 
 VERSION_CLEANUP=make version-cleanup || { make version-cleanup; exit 1; }
 
+ARCH = x86_64
 GIT_VERSION = $(shell git describe --match "v[0-9]*" --always --long | sed -e "s/-.*//")
 GIT_BUILD = $(shell git describe --match "v[0-9]*" --always --long)
 GIT_COMMIT = $(shell git describe --match "v[0-9]*" --always --long | sed -e "s/.*-g//")

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ docker run -tv $(pwd):/files caption-inspector -o /files /files/test/media/Plan9
 docker run -tv $(pwd):/files caption-inspector -o /files /files/test/media/NightOfTheLivingDead.mcc
 ```
 
+Use `make docker ARCH=aarch64` instead of `make docker` if you are using arm64 host.
 In the `docker run` command, your current working directory will be remapped to `/files` inside of the container, so
 you will need to prefix your input and output paths to that so that it can place the files in the correct spot. For
 this example, the output file is located in the current directory `./` and the input file is located in a directory


### PR DESCRIPTION
Debian 9 is EOL so it's updated to actual one
Dockerfile had hardcoded x86_64 file names, replaced to $ARCH